### PR TITLE
Fix Spacing on Chain Icons

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -188,7 +188,7 @@ body {
   display: flex;
   align-content: center;
   text-decoration: none;
-  margin: 0 1rem;
+  margin: 0 1rem 1.7rem 1rem;
   transition: all .1s ease-out; 
 }
 


### PR DESCRIPTION
<img width="240" alt="Before" src="https://user-images.githubusercontent.com/4100078/150457165-60067277-48e3-49ac-b258-077b36841cae.png"> → <img width="240" alt="After" src="https://user-images.githubusercontent.com/4100078/150457191-3203e7bf-6417-4c06-a7dd-a0e774aec03e.png">